### PR TITLE
Enable WASM Relaxed SIMD support in Tesseract for tesseract.js-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,13 +708,64 @@ if(DISABLED_LEGACY_ENGINE)
 endif(DISABLED_LEGACY_ENGINE)
 
 if (WASM_BUILD)
-if(NOT HAVE_SSE4_1)
-  list(APPEND arch_files src/arch/dotproduct.cpp src/arch/simddetect.cpp
-      src/arch/intsimdmatrix.cpp)
-else()
-    list(APPEND arch_files_opt src/arch_sse/dotproductsse.cpp src/arch_sse/simddetect.cpp src/arch_sse/intsimdmatrix.cpp src/arch_sse/intsimdmatrixsse.cpp src/arch_sse/dotproduct.cpp)
-    set_source_files_properties(src/arch_sse/dotproductsse.cpp src/arch_sse/simddetect.cpp src/arch_sse/intsimdmatrix.cpp src/arch_sse/intsimdmatrixsse.cpp  src/arch_sse/dotproduct.cpp PROPERTIES COMPILE_FLAGS "-DSSE4_1 -msimd128 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2 -Wno-argument-outside-range")
-endif(NOT HAVE_SSE4_1)
+
+  set(SSE_SIMD_COMMON_FILES
+      src/arch_sse/simddetect.cpp
+      src/arch_sse/intsimdmatrix.cpp
+      src/arch_sse/intsimdmatrixsse.cpp
+      src/arch_sse/dotproduct.cpp
+  )
+
+  set(SIMD_FLAGS_AVX2
+      "-DSSE4_1 -D__AVX2__ -D__AVX__ \
+      -msimd128 -mrelaxed-simd \
+      -mavx -mavx2 \
+      -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2 \
+      -Wno-argument-outside-range"
+  )
+
+  set(SIMD_FLAGS_SSE41
+      "-DSSE4_1 \
+      -msimd128 \
+      -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2 \
+      -Wno-argument-outside-range"
+  )
+
+  if(HAVE_AVX2)
+      list(APPEND arch_files_opt
+          ${SSE_SIMD_COMMON_FILES}
+          src/arch_sse/dotproductavx.cpp
+          src/arch_sse/intsimdmatrixavx2.cpp
+      )
+
+      set_source_files_properties(
+          ${SSE_SIMD_COMMON_FILES}
+          src/arch_sse/dotproductavx.cpp
+          src/arch_sse/intsimdmatrixavx2.cpp
+          PROPERTIES
+              COMPILE_FLAGS "${SIMD_FLAGS_AVX2}"
+      )
+
+  elseif(HAVE_SSE4_1)
+      list(APPEND arch_files_opt
+          ${SSE_SIMD_COMMON_FILES}
+          src/arch_sse/dotproductsse.cpp
+      )
+
+      set_source_files_properties(
+          ${SSE_SIMD_COMMON_FILES}
+          src/arch_sse/dotproductsse.cpp
+          PROPERTIES
+              COMPILE_FLAGS "${SIMD_FLAGS_SSE41}"
+      )
+
+  else()
+      list(APPEND arch_files
+          src/arch/dotproduct.cpp
+          src/arch/simddetect.cpp
+          src/arch/intsimdmatrix.cpp
+      )
+  endif()
 
 else()
 
@@ -1056,7 +1107,13 @@ endif()
 ########################################
 # Build tesseract-core.js (WASM version)
 ########################################
-if(HAVE_SSE4_1)
+if(HAVE_AVX2)
+  if(DISABLED_LEGACY_ENGINE)
+    set(WASM_NAME tesseract-core-relaxedsimd-lstm)
+  else()
+    set(WASM_NAME tesseract-core-relaxedsimd)
+  endif()
+elseif(HAVE_SSE4_1)
   if(DISABLED_LEGACY_ENGINE)
     set(WASM_NAME tesseract-core-simd-lstm)
   else()

--- a/src/arch_sse/intsimdmatrixavx2.cpp
+++ b/src/arch_sse/intsimdmatrixavx2.cpp
@@ -17,15 +17,32 @@
 
 #include "intsimdmatrix.h"
 
-#if !defined(__AVX2__)
+#if !defined(__AVX2__) || !defined(__wasm_relaxed_simd__)
 #  if defined(__i686__) || defined(__x86_64__)
 #    error Implementation only for AVX2 capable architectures
+#  elif defined(__EMSCRIPTEN__) || defined(__wasm__)
+#    error "Implementation requires WebAssembly Relaxed SIMD support (-mrelaxed-simd). "
 #  endif
 #else
 #  include <immintrin.h>
 #  include <algorithm>
 #  include <cstdint>
 #  include <vector>
+
+#if defined(__wasm_relaxed_simd__)
+#include <wasm_simd128.h>
+
+namespace {
+
+inline __m256i __wasm_relaxed_dot_i8x16x2_add_epi32(__m256i acc, __m256i a, __m256i b) {
+  __m256i ret;
+  ret.v0 = (__m128i) wasm_i32x4_relaxed_dot_i8x16_i7x16_add((v128_t )(b.v0), (v128_t )(a.v0), (v128_t )(acc.v0));
+  ret.v1 = (__m128i) wasm_i32x4_relaxed_dot_i8x16_i7x16_add((v128_t )(b.v1), (v128_t )(a.v1), (v128_t )(acc.v1));
+  return ret;
+}
+
+}
+#endif
 
 namespace tesseract {
 
@@ -60,21 +77,14 @@ constexpr int kNumInputGroups = kNumInputsPerRegister / kNumInputsPerGroup;
 static inline void MultiplyGroup(const __m256i &rep_input, const __m256i &ones, const int8_t *&wi,
                                  __m256i &weights, __m256i &reps, __m256i &result) {
   // Load a 4x8 block of weights.
-  weights = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(wi));
+  weights = _mm256_loadu_si256(reinterpret_cast<const __m256i_u *>(wi));
   wi += kNumInputsPerRegister;
-  // Normalize the signs on rep_input, weights, so weights is always +ve.
-  reps = _mm256_sign_epi8(rep_input, weights);
-  weights = _mm256_sign_epi8(weights, weights);
-  // Multiply 32x8-bit reps by 32x8-bit weights to make 16x16-bit results,
-  // with adjacent pairs added.
-  weights = _mm256_maddubs_epi16(weights, reps);
-  // Multiply 16x16-bit result by 16x16-bit ones to make 8x32-bit results,
-  // with  adjacent pairs added. What we really want is a horizontal add of
-  // 16+16=32 bit result, but there is no such instruction, so multiply by
-  // 16-bit ones instead. It is probably faster than all the sign-extending,
-  // permuting and adding that would otherwise be required.
-  weights = _mm256_madd_epi16(weights, ones);
-  result = _mm256_add_epi32(result, weights);
+
+
+  reps = rep_input;
+  weights = weights;
+
+  result = __wasm_relaxed_dot_i8x16x2_add_epi32(result, weights, reps);
 }
 
 // Load 64 bits into the bottom of a 128bit register.
@@ -154,14 +164,11 @@ static void PartialMatrixDotVector64(const int8_t *wi, const float *scales, cons
   __m256i result7 = _mm256_setzero_si256();
   // Iterate over the input (u), one registerful at a time.
   for (int j = 0; j < num_in;) {
-    __m256i inputs = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u + j));
     // Inputs are processed in groups of kNumInputsPerGroup, replicated
     // kNumInputGroups times.
     for (int ig = 0; ig < kNumInputGroups && j < num_in; ++ig, j += kNumInputsPerGroup) {
       // Replicate the low 32 bits (4 inputs) 8 times.
-      __m256i rep_input = _mm256_broadcastd_epi32(_mm256_castsi256_si128(inputs));
-      // Rotate the inputs in groups of 4, so the next 4 inputs are ready.
-      inputs = _mm256_permutevar8x32_epi32(inputs, shift_id);
+      __m256i rep_input = _mm256_broadcastd_epi32(_mm_loadu_si32(u + j));
       __m256i weights, reps;
       // Mul-add, with horizontal add of the 4 inputs to each of the results.
       MultiplyGroup(rep_input, ones, wi, weights, reps, result0);
@@ -195,14 +202,11 @@ static void PartialMatrixDotVector32(const int8_t *wi, const float *scales, cons
   __m256i result3 = _mm256_setzero_si256();
   // Iterate over the input (u), one registerful at a time.
   for (int j = 0; j < num_in;) {
-    __m256i inputs = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u + j));
     // Inputs are processed in groups of kNumInputsPerGroup, replicated
     // kNumInputGroups times.
     for (int ig = 0; ig < kNumInputGroups && j < num_in; ++ig, j += kNumInputsPerGroup) {
       // Replicate the low 32 bits (4 inputs) 8 times.
-      __m256i rep_input = _mm256_broadcastd_epi32(_mm256_castsi256_si128(inputs));
-      // Rotate the inputs in groups of 4, so the next 4 inputs are ready.
-      inputs = _mm256_permutevar8x32_epi32(inputs, shift_id);
+      __m256i rep_input = _mm256_broadcastd_epi32(_mm_loadu_si32(u + j));
       __m256i weights, reps;
       // Mul-add, with horizontal add of the 4 inputs to each of the results.
       MultiplyGroup(rep_input, ones, wi, weights, reps, result0);
@@ -228,14 +232,11 @@ static void PartialMatrixDotVector16(const int8_t *wi, const float *scales, cons
   __m256i result1 = _mm256_setzero_si256();
   // Iterate over the input (u), one registerful at a time.
   for (int j = 0; j < num_in;) {
-    __m256i inputs = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u + j));
     // Inputs are processed in groups of kNumInputsPerGroup, replicated
     // kNumInputGroups times.
     for (int ig = 0; ig < kNumInputGroups && j < num_in; ++ig, j += kNumInputsPerGroup) {
       // Replicate the low 32 bits (4 inputs) 8 times.
-      __m256i rep_input = _mm256_broadcastd_epi32(_mm256_castsi256_si128(inputs));
-      // Rotate the inputs in groups of 4, so the next 4 inputs are ready.
-      inputs = _mm256_permutevar8x32_epi32(inputs, shift_id);
+      __m256i rep_input = _mm256_broadcastd_epi32(_mm_loadu_si32(u + j));
       __m256i weights, reps;
       // Mul-add, with horizontal add of the 4 inputs to each of the results.
       MultiplyGroup(rep_input, ones, wi, weights, reps, result0);
@@ -257,14 +258,11 @@ static inline void PartialMatrixDotVector8(const int8_t *wi, const float *scales
   __m256i result0 = _mm256_setzero_si256();
   // Iterate over the input (u), one registerful at a time.
   for (int j = 0; j < num_in;) {
-    __m256i inputs = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u + j));
     // Inputs are processed in groups of kNumInputsPerGroup, replicated
     // kNumInputGroups times.
     for (int ig = 0; ig < kNumInputGroups && j < num_in; ++ig, j += kNumInputsPerGroup) {
       // Replicate the low 32 bits (4 inputs) 8 times.
-      __m256i rep_input = _mm256_broadcastd_epi32(_mm256_castsi256_si128(inputs));
-      // Rotate the inputs in groups of 4, so the next 4 inputs are ready.
-      inputs = _mm256_permutevar8x32_epi32(inputs, shift_id);
+      __m256i rep_input = _mm256_broadcastd_epi32(_mm_loadu_si32(u + j));
       __m256i weights, reps;
       // Mul-add, with horizontal add of the 4 inputs to each of the results.
       MultiplyGroup(rep_input, ones, wi, weights, reps, result0);
@@ -399,14 +397,11 @@ static void PartialMatrixDotVector64(const int8_t *wi, const double *scales, con
   __m256i result7 = _mm256_setzero_si256();
   // Iterate over the input (u), one registerful at a time.
   for (int j = 0; j < num_in;) {
-    __m256i inputs = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u + j));
     // Inputs are processed in groups of kNumInputsPerGroup, replicated
     // kNumInputGroups times.
     for (int ig = 0; ig < kNumInputGroups && j < num_in; ++ig, j += kNumInputsPerGroup) {
       // Replicate the low 32 bits (4 inputs) 8 times.
-      __m256i rep_input = _mm256_broadcastd_epi32(_mm256_castsi256_si128(inputs));
-      // Rotate the inputs in groups of 4, so the next 4 inputs are ready.
-      inputs = _mm256_permutevar8x32_epi32(inputs, shift_id);
+      __m256i rep_input = _mm256_broadcastd_epi32(_mm_loadu_si32(u + j));
       __m256i weights, reps;
       // Mul-add, with horizontal add of the 4 inputs to each of the results.
       MultiplyGroup(rep_input, ones, wi, weights, reps, result0);
@@ -440,14 +435,11 @@ static void PartialMatrixDotVector32(const int8_t *wi, const double *scales, con
   __m256i result3 = _mm256_setzero_si256();
   // Iterate over the input (u), one registerful at a time.
   for (int j = 0; j < num_in;) {
-    __m256i inputs = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u + j));
     // Inputs are processed in groups of kNumInputsPerGroup, replicated
     // kNumInputGroups times.
     for (int ig = 0; ig < kNumInputGroups && j < num_in; ++ig, j += kNumInputsPerGroup) {
       // Replicate the low 32 bits (4 inputs) 8 times.
-      __m256i rep_input = _mm256_broadcastd_epi32(_mm256_castsi256_si128(inputs));
-      // Rotate the inputs in groups of 4, so the next 4 inputs are ready.
-      inputs = _mm256_permutevar8x32_epi32(inputs, shift_id);
+      __m256i rep_input = _mm256_broadcastd_epi32(_mm_loadu_si32(u + j));
       __m256i weights, reps;
       // Mul-add, with horizontal add of the 4 inputs to each of the results.
       MultiplyGroup(rep_input, ones, wi, weights, reps, result0);
@@ -502,14 +494,11 @@ static inline void PartialMatrixDotVector8(const int8_t *wi, const double *scale
   __m256i result0 = _mm256_setzero_si256();
   // Iterate over the input (u), one registerful at a time.
   for (int j = 0; j < num_in;) {
-    __m256i inputs = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(u + j));
     // Inputs are processed in groups of kNumInputsPerGroup, replicated
     // kNumInputGroups times.
     for (int ig = 0; ig < kNumInputGroups && j < num_in; ++ig, j += kNumInputsPerGroup) {
       // Replicate the low 32 bits (4 inputs) 8 times.
-      __m256i rep_input = _mm256_broadcastd_epi32(_mm256_castsi256_si128(inputs));
-      // Rotate the inputs in groups of 4, so the next 4 inputs are ready.
-      inputs = _mm256_permutevar8x32_epi32(inputs, shift_id);
+      __m256i rep_input = _mm256_broadcastd_epi32(_mm_loadu_si32(u + j));
       __m256i weights, reps;
       // Mul-add, with horizontal add of the 4 inputs to each of the results.
       MultiplyGroup(rep_input, ones, wi, weights, reps, result0);

--- a/src/arch_sse/simddetect.cpp
+++ b/src/arch_sse/simddetect.cpp
@@ -66,6 +66,27 @@
 #  endif
 #endif
 
+namespace {
+
+#if defined(__wasm_relaxed_simd__)
+#include <wasm_simd128.h>
+
+bool ProbeWasmSDot() {
+  // Check out-of-bounds behaviour of Relaxed Integer Dot Product with Accumulation with signed input (e.g. vpdpbssd, sdot).
+  const v128_t int8_input = wasm_i8x16_const(0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0);
+  const volatile v128_t xint8_input = wasm_i8x16_const(0, 0, 0, -128, 0, 0, -128, 0, 0, -128, 0, 0, -128, 0, 0, 0);
+  const v128_t xint8_output = wasm_i32x4_relaxed_dot_i8x16_i7x16_add(int8_input, xint8_input, wasm_i8x16_const_splat(0));
+
+  const volatile v128_t overflow_input = wasm_i8x16_const(-128, -128, -128, -128, -128, -128, -1, -1, -1, -1, -128, -128, -1, -1, -1, -1);
+  const v128_t overflow_output = wasm_i32x4_relaxed_dot_i8x16_i7x16_add(wasm_i8x16_const_splat(-128), overflow_input, wasm_i8x16_const_splat(0));
+  return !wasm_v128_any_true(wasm_v128_or(
+    wasm_v128_xor(xint8_output, wasm_i32x4_const_splat(-128)),
+    wasm_v128_xor(overflow_output, wasm_i32x4_const(65536, 33024, 33024, 512))));
+}
+#endif
+
+}
+
 namespace tesseract {
 
 // Computes and returns the dot product of the two n-vectors u and v.
@@ -90,6 +111,8 @@ bool SIMDDetect::neon_available_ = true;
 #elif defined(HAVE_NEON)
 // If true, then Neon has been detected.
 bool SIMDDetect::neon_available_;
+#elif defined(__wasm_relaxed_simd__)
+bool SIMDDetect::wasm_sdot_;
 #else
 // If true, then AVX has been detected.
 bool SIMDDetect::avx_available_;
@@ -140,22 +163,48 @@ static void SetDotProduct(DotProductFunction f, const IntSimdMatrix *m = nullptr
 // __GNUC__ is also defined by compilers that include GNU extensions such as
 // clang.
 SIMDDetect::SIMDDetect() {
-  // The fallback is a generic dot product calculation.
-  SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
+  const char *dotproduct_method = "null";
 
-  const char *dotproduct_env = getenv("DOTPRODUCT");
-  if (dotproduct_env != nullptr) {
-    // Override automatic settings by value from environment variable.
-    dotproduct = dotproduct_env;
-    Update();
+#if defined(__wasm_relaxed_simd__)
+  wasm_sdot_  = ProbeWasmSDot();
+
+  if (wasm_sdot_) {
+    // Our AVX2 “int” backend is the wasm-relaxed-simd implementation
+    // that internally uses the relaxed dot instruction.
+    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixAVX2);
+    dotproduct_method = "wasm-relaxed-sdot";
+  } else {
+    SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
+    dotproduct_method = "sse4_1";
   }
+#else  // !__wasm_relaxed_simd__
+  #if defined(__wasm_simd128__)
+    SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
+    dotproduct_method = "sse4_1";
+  #else
+    dotproduct_method = "fallback";
+  #endif
+#endif
 }
 
 void SIMDDetect::Update() {
 
-  SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
-
-  dotproduct.set_value("sse");
+#if defined(__wasm_relaxed_simd__)
+  if (wasm_sdot_) {
+    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixAVX2);
+    dotproduct.set_value("wasm-relaxed-sdot");
+  } else {
+    SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
+    dotproduct.set_value("sse4_1");
+  }
+#else
+  #if defined(__wasm_simd128__)
+    SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
+    dotproduct.set_value("sse4_1");
+  #else
+    dotproduct.set_value("fallback");
+  #endif
+#endif
 }
 
 } // namespace tesseract

--- a/src/arch_sse/simddetect.h
+++ b/src/arch_sse/simddetect.h
@@ -60,6 +60,10 @@ public:
     return detector.neon_available_;
   }
 
+#if defined(__wasm_relaxed_simd__)
+  static bool HasSDot() { return detector.wasm_sdot_; };
+#endif
+
   // Update settings after config variable was set.
   static TESS_API void Update();
 
@@ -81,6 +85,10 @@ private:
   static TESS_API bool sse_available_;
   // If true, then NEON has been detected.
   static TESS_API bool neon_available_;
+
+#if defined(__wasm_relaxed_simd__)
+  static TESS_API bool wasm_sdot_;
+#endif
 };
 
 } // namespace tesseract


### PR DESCRIPTION
This PR applies necessary change needed in tesseract to enable WASM Relaxed SIMD build for tesseract.js-core.

## Key changes

1. Build system update
3. intsimdmatrixavx2 backend
    - Replace sign-fix/maddubs+madd pipeline with a single relaxed-SIMD dot-product instruction.
    - Replace _mm256_permutevar8x32_epi32 with simple broadcast from memory to avoid scalar fallback codegen in WASM.
5. SIMD auto detection
    - Add runtime probing for relaxed-SIMD dot-product correctness. Engine supporting vpdpbssd or sdot automatically select relaxed SIMD backend.

