### PR TITLE
Optimize SSE intsimdmatrix for tesseract.js-core WASM SIMD build

### DIFF
--- a/src/arch_sse/intsimdmatrixsse.cpp
+++ b/src/arch_sse/intsimdmatrixsse.cpp
@@ -29,77 +29,229 @@
 
 namespace tesseract {
 
-// Computes and returns the dot product of the n-vectors u and v.
-// Uses Intel SSE intrinsics to access the SIMD instruction set.
-static int32_t IntDotProductSSE(const int8_t *u, const int8_t *v, int n) {
-  int max_offset = n - 8;
-  int offset = 0;
-  // Accumulate a set of 4 32-bit sums in sum, by loading 8 pairs of 8-bit
-  // values, extending to 16 bit, multiplying to make 32 bit results.
-  int32_t result = 0;
-  if (offset <= max_offset) {
-    offset = 8;
-    __m128i packed1 = _mm_loadl_epi64(reinterpret_cast<const __m128i *>(u));
-    __m128i packed2 = _mm_loadl_epi64(reinterpret_cast<const __m128i *>(v));
-    __m128i sum = _mm_cvtepi8_epi16(packed1);
-    packed2 = _mm_cvtepi8_epi16(packed2);
-    // The magic _mm_add_epi16 is perfect here. It multiplies 8 pairs of 16 bit
-    // ints to make 32 bit results, which are then horizontally added in pairs
-    // to make 4 32 bit results that still fit in a 128 bit register.
-    sum = _mm_madd_epi16(sum, packed2);
-    while (offset <= max_offset) {
-      packed1 = _mm_loadl_epi64(reinterpret_cast<const __m128i *>(u + offset));
-      packed2 = _mm_loadl_epi64(reinterpret_cast<const __m128i *>(v + offset));
-      offset += 8;
-      packed1 = _mm_cvtepi8_epi16(packed1);
-      packed2 = _mm_cvtepi8_epi16(packed2);
-      packed1 = _mm_madd_epi16(packed1, packed2);
-      sum = _mm_add_epi32(sum, packed1);
-    }
-    // Sum the 4 packed 32 bit sums and extract the low result.
-    sum = _mm_hadd_epi32(sum, sum);
-    sum = _mm_hadd_epi32(sum, sum);
-    result = _mm_cvtsi128_si32(sum);
+// --- SSE backend configuration ---
+constexpr int kNumOutputsPerRegister   = 1;
+constexpr int kMaxOutputRegisters      = 1;
+constexpr int kNumInputsPerRegister    = 1;
+constexpr int kNumInputsPerGroup       = 2;
+
+static inline void IntDotProduct4xSSE_u16_w8(
+    const int16_t* __restrict u16,
+    const int8_t*  __restrict w0,
+    const int8_t*  __restrict w1,
+    const int8_t*  __restrict w2,
+    const int8_t*  __restrict w3,
+    int n,
+    int32_t& out0, int32_t& out1, int32_t& out2, int32_t& out3) {
+
+  int off = 0;
+  __m128i acc0 = _mm_setzero_si128();
+  __m128i acc1 = _mm_setzero_si128();
+  __m128i acc2 = _mm_setzero_si128();
+  __m128i acc3 = _mm_setzero_si128();
+
+  for (; off + 16 <= n; off += 16) {
+    // Load 16 int16 inputs: split into low/high 8.
+    __m128i u_lo = _mm_loadu_si128(reinterpret_cast<const __m128i*>(u16 + off));
+    __m128i u_hi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(u16 + off + 8));
+
+    // Load 4 rows of weights
+    __m128i w0v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w0 + off));
+    __m128i w1v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w1 + off));
+    __m128i w2v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w2 + off));
+    __m128i w3v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w3 + off));
+
+    // Expand low/high 8 bytes -> 8x i16
+    __m128i w0_lo = _mm_cvtepi8_epi16(w0v);
+    __m128i w0_hi = _mm_cvtepi8_epi16(_mm_srli_si128(w0v, 8));
+    __m128i w1_lo = _mm_cvtepi8_epi16(w1v);
+    __m128i w1_hi = _mm_cvtepi8_epi16(_mm_srli_si128(w1v, 8));
+    __m128i w2_lo = _mm_cvtepi8_epi16(w2v);
+    __m128i w2_hi = _mm_cvtepi8_epi16(_mm_srli_si128(w2v, 8));
+    __m128i w3_lo = _mm_cvtepi8_epi16(w3v);
+    __m128i w3_hi = _mm_cvtepi8_epi16(_mm_srli_si128(w3v, 8));
+
+    // Pmaddwd
+    acc0 = _mm_add_epi32(acc0, _mm_madd_epi16(u_lo, w0_lo));
+    acc0 = _mm_add_epi32(acc0, _mm_madd_epi16(u_hi, w0_hi));
+
+    acc1 = _mm_add_epi32(acc1, _mm_madd_epi16(u_lo, w1_lo));
+    acc1 = _mm_add_epi32(acc1, _mm_madd_epi16(u_hi, w1_hi));
+
+    acc2 = _mm_add_epi32(acc2, _mm_madd_epi16(u_lo, w2_lo));
+    acc2 = _mm_add_epi32(acc2, _mm_madd_epi16(u_hi, w2_hi));
+
+    acc3 = _mm_add_epi32(acc3, _mm_madd_epi16(u_lo, w3_lo));
+    acc3 = _mm_add_epi32(acc3, _mm_madd_epi16(u_hi, w3_hi));
   }
-  while (offset < n) {
-    result += u[offset] * v[offset];
-    ++offset;
+
+  // horizontal sum helper
+  auto hsum4 = [](__m128i v) -> int32_t {
+    __m128i tmp = _mm_shuffle_epi32(v, _MM_SHUFFLE(1,0,3,2));
+    v = _mm_add_epi32(v, tmp);
+    tmp = _mm_shuffle_epi32(v, _MM_SHUFFLE(2,3,0,1));
+    v = _mm_add_epi32(v, tmp);
+    return _mm_cvtsi128_si32(v);
+  };
+
+  int32_t s0 = hsum4(acc0);
+  int32_t s1 = hsum4(acc1);
+  int32_t s2 = hsum4(acc2);
+  int32_t s3 = hsum4(acc3);
+
+  // scalar tail
+  for (; off < n; ++off) {
+    int32_t uval = static_cast<int32_t>(u16[off]);
+    s0 += uval * static_cast<int32_t>(w0[off]);
+    s1 += uval * static_cast<int32_t>(w1[off]);
+    s2 += uval * static_cast<int32_t>(w2[off]);
+    s3 += uval * static_cast<int32_t>(w3[off]);
+  }
+
+  out0 = s0; out1 = s1; out2 = s2; out3 = s3;
+}
+
+// Dot product between pre-expanded u16 (int16) and weights w8 (int8).
+// n = rounded_num_in (multiple of kNumInputsPerGroup).
+static inline int32_t IntDotProductSSE_u16(const int16_t* __restrict u16,
+                                           const int8_t*  __restrict w8,
+                                           int n) {
+  int offset = 0;
+  __m128i acc0 = _mm_setzero_si128();
+  __m128i acc1 = _mm_setzero_si128();
+
+  // Main loop: 16 inputs per iteration.
+  for (; offset + 16 <= n; offset += 16) {
+    // Load 16 int16 inputs: split into low/high 8.
+    __m128i u_lo = _mm_loadu_si128(reinterpret_cast<const __m128i*>(u16 + offset));      // 8x i16
+    __m128i u_hi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(u16 + offset + 8));  // 8x i16
+
+    // Load 16 weight bytes.
+    __m128i w   = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w8 + offset));
+    __m128i w_lo = _mm_cvtepi8_epi16(w);                      // low 8 -> 8x i16
+    __m128i w_hi = _mm_cvtepi8_epi16(_mm_srli_si128(w, 8));   // high 8 -> 8x i16
+
+    // Pmaddwd
+    acc0 = _mm_add_epi32(acc0, _mm_madd_epi16(u_lo, w_lo));
+    acc1 = _mm_add_epi32(acc1, _mm_madd_epi16(u_hi, w_hi));
+  }
+
+  __m128i sum = _mm_add_epi32(acc0, acc1);
+
+  // Leftover 8 inputs.
+  if (offset + 8 <= n) {
+    __m128i u8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(u16 + offset)); // 8x i16
+    __m128i w8v = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(w8 + offset)); // 8x i8 in low 64b
+    offset += 8;
+
+    __m128i w16 = _mm_cvtepi8_epi16(w8v);
+    sum = _mm_add_epi32(sum, _mm_madd_epi16(u8, w16));
+  }
+
+  // Horizontal sum of 4 lanes.
+  __m128i tmp = _mm_shuffle_epi32(sum, _MM_SHUFFLE(1,0,3,2));
+  sum = _mm_add_epi32(sum, tmp);
+  tmp = _mm_shuffle_epi32(sum, _MM_SHUFFLE(2,3,0,1));
+  sum = _mm_add_epi32(sum, tmp);
+
+  int32_t result = _mm_cvtsi128_si32(sum);
+
+  // Scalar tail (0–7 inputs).
+  for (; offset < n; ++offset) {
+    result += static_cast<int32_t>(u16[offset]) *
+              static_cast<int32_t>(w8[offset]);
   }
   return result;
 }
 
 // Computes part of matrix.vector v = Wu. Computes 1 result.
-static void PartialMatrixDotVector1(const int8_t *wi, const TFloat *scales, const int8_t *u,
-                                    int num_in, TFloat *v) {
-  TFloat total = IntDotProductSSE(u, wi, num_in);
-  // Add in the bias and correct for integer values.
-  *v = (total + wi[num_in] * INT8_MAX) * *scales;
+static inline void PartialMatrixDotVector1_u16(const int8_t* wi,
+                                               const TFloat* scale,
+                                               const int16_t* u16,
+                                               int rounded_num_in,
+                                               TFloat* v) {
+  int32_t total = IntDotProductSSE_u16(u16, wi, rounded_num_in);
+  int32_t bias  = static_cast<int32_t>(wi[rounded_num_in]) * INT8_MAX;
+  *v = (total + bias) * *scale;
 }
 
-static void matrixDotVector(int dim1, int dim2, const int8_t *wi, const TFloat *scales,
-                            const int8_t *u, TFloat *v) {
+static void matrixDotVector(int dim1, int dim2,
+                            const int8_t* wi,
+                            const TFloat* scales,
+                            const int8_t* u,
+                            TFloat* v) {
   const int num_out = dim1;
   const int num_in = dim2 - 1;
-  int output = 0;
 
-  for (; output < num_out; output++) {
-    PartialMatrixDotVector1(wi, scales, u, num_in, v);
-    wi += dim2;
-    scales++;
-    v++;
+  const int rounded_num_in =
+      IntSimdMatrix::Roundup(num_in, kNumInputsPerGroup);
+  const int row_stride = rounded_num_in + 1;
+
+  // --- Pre-expand u to int16 once ---
+  std::vector<int16_t> u16;
+  u16.resize(rounded_num_in, 0);
+
+  int i = 0;
+  // Vectorized expand in chunks of 16 bytes.
+  for (; i + 16 <= num_in; i += 16) {
+    __m128i u8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(u + i));
+    __m128i lo = _mm_cvtepi8_epi16(u8);                     // first 8
+    __m128i hi = _mm_cvtepi8_epi16(_mm_srli_si128(u8, 8));  // next 8
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(u16.data() + i), lo);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(u16.data() + i + 8), hi);
   }
+  // Tail for remaining inputs.
+  for (; i < num_in; ++i) {
+    u16[i] = static_cast<int16_t>(u[i]);
+  }
+  // Any padded elements [num_in .. rounded_num_in) stay 0.
+
+  int out = 0;
+  
+  // ---- 4-row fusion ----
+  for (; out + 3 < num_out; out += 4) {
+    int32_t s0, s1, s2, s3;
+    IntDotProduct4xSSE_u16_w8(u16.data(),
+                              wi + 0*row_stride,
+                              wi + 1*row_stride,
+                              wi + 2*row_stride,
+                              wi + 3*row_stride,
+                              rounded_num_in,
+                              s0, s1, s2, s3);
+
+    int32_t b0 = wi[0*row_stride + rounded_num_in] * INT8_MAX;
+    int32_t b1 = wi[1*row_stride + rounded_num_in] * INT8_MAX;
+    int32_t b2 = wi[2*row_stride + rounded_num_in] * INT8_MAX;
+    int32_t b3 = wi[3*row_stride + rounded_num_in] * INT8_MAX;
+
+    v[0] = (s0 + b0) * scales[0];
+    v[1] = (s1 + b1) * scales[1];
+    v[2] = (s2 + b2) * scales[2];
+    v[3] = (s3 + b3) * scales[3];
+
+    wi     += 4 * row_stride;
+    scales += 4;
+    v      += 4;
+  }
+
+  // tail (0~3 outputs)
+  for (; out < num_out; ++out) {
+    PartialMatrixDotVector1_u16(wi, scales, u16.data(), rounded_num_in, v);
+    wi += row_stride; ++scales; ++v;
+  }
+
 }
 
 const IntSimdMatrix IntSimdMatrix::intSimdMatrixSSE = {
     matrixDotVector,
     // Number of 32 bit outputs held in each register.
-    1,
+    kNumOutputsPerRegister,
     // Maximum number of registers that we will use to hold outputs.
-    1,
+    kMaxOutputRegisters,
     // Number of 8 bit inputs in the inputs register.
-    1,
+    kNumInputsPerRegister,
     // Number of inputs in each weight group.
-    1
+    kNumInputsPerGroup
 };
 
 } // namespace tesseract.


### PR DESCRIPTION
This PR refactors the SSE backend in intsimdmatrix to provide more efficient execution path for tesseract.js-core WASM SIMD build. The updated implementation pre-expands the input vector to int16 once and uses fused multi-row dot-product kernels based on pmaddwd.

## Key Changes
- Pre-expand inputs to int16 to avoid repeated extend on u.
- Replace legacy 8-byte loop with 16-element kernels.
- Add 4-row fused dot-product kernel to increase throughput and reduce loop overhead.

## Performance Impact
Measured on Intel Ultra 7 155H with node v25.2.1, using node --no-liftoff ./benchmark.wasm-simd.js
|              | Baseline | Optimized    | Speedup |
|-----------------|----------|--------|---------|
| meditations.jpg [x10] | 22.936   | 19.385 | 18%     |
| tyger.jpg [x10]       | 14.273   | 11.867 | 20%     |
| testocr.png [x10]     | 2.958    | 2.309  | 28%     |
| Doc_1.png [x10]       | 18.899   | 15.04  | 26%     |

Overall speedups range from 18% to 28%, depending on input image.

## Correctness
Verified against native intsimdmatrix_test target.